### PR TITLE
fix IP Regex palo-object-generator.html

### DIFF
--- a/PaloAlto/palo-object-generator.html
+++ b/PaloAlto/palo-object-generator.html
@@ -74,7 +74,7 @@ function generateCommands() {
 
   inputList.forEach(entry => {
     entry = entry.trim();
-    let isIP = /^\d{1,3}(\.\d{1,3}){3}(\/\d{1,2})?$/.test(entry);
+    let isIP = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}$/.test(entry);
     let ip = "", mask = "", fqdn = "";
 
     if (isIP) {


### PR DESCRIPTION
256.256.256.256 was a valid IP, changed the Regex. ^(?!((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$)[0-9.]+$ to catch invalid IPs